### PR TITLE
Fix build errors

### DIFF
--- a/inc/csuit/suit_common.h
+++ b/inc/csuit/suit_common.h
@@ -585,7 +585,7 @@ typedef struct suit_delegation_chain {
  * SUIT_Delegation
  */
 typedef struct suit_delegation {
-    size_t                  delegation_chain_num;;
+    size_t                  delegation_chain_num;
     suit_delegation_chain_t delegation_chains[SUIT_MAX_KEY_NUM];
 } suit_delegation_t;
 

--- a/src/suit_cose.c
+++ b/src/suit_cose.c
@@ -493,7 +493,7 @@ suit_err_t suit_set_mechanism_from_cose_key_from_item(QCBORDecodeContext *contex
     int64_t crv = 0;
     int64_t kty = 0;
     union {
-        UsefulBufC k;; // k for Symmetric
+        UsefulBufC k; // k for Symmetric
         struct {
             UsefulBufC x; // x for EC2
             UsefulBufC y; // y for EC2


### PR DESCRIPTION
Currently libcsuit fails to compile with MSVC due to double semicolon errors.
This appears to be a regression recently introduced in commit f0b9176e.