### PR TITLE
Add several arguments to callback functions

### DIFF
--- a/examples/encode/suit_manifest_encode_main.c
+++ b/examples/encode/suit_manifest_encode_main.c
@@ -53,11 +53,10 @@ int main(int argc, char *argv[]) {
     manifest->version = 1;
     manifest->sequence_number = 2;
 
-    uint8_t component_id[] = {0x00};
+    uint8_t component_id[] = {0x81, 0x41, 0x00}; // [ h'00' ]
     suit_common_t *common = &manifest->common;
     common->components_len = 1;
-    common->components[0].component.len = 1;
-    common->components[0].component.identifier[0] = (UsefulBufC){.ptr = component_id, .len = sizeof(component_id)};
+    common->components[0].encoded_component = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(component_id);
 
     uint8_t vendor_id[] = {0xFA, 0x6B, 0x4A, 0x53, 0xD5, 0xAD, 0x5F, 0xDF, 0xBE, 0x9D, 0xE6, 0x63, 0xE4, 0xD4, 0x1F, 0xFE};
     uint8_t class_id[] = {0x14, 0x92, 0xAF, 0x14, 0x25, 0x69, 0x5E, 0x48, 0xBF, 0x42, 0x9B, 0x2D, 0x51, 0xF2, 0xAB, 0x45};

--- a/inc/csuit/suit_common.h
+++ b/inc/csuit/suit_common.h
@@ -422,16 +422,16 @@ typedef struct suit_component_identifier {
     UsefulBufC                      identifier[SUIT_MAX_ARRAY_LENGTH];
 } suit_component_identifier_t;
 
-typedef struct suit_component_with_index {
+typedef struct suit_encoded_component_with_index {
     uint8_t                         index;
-    suit_component_identifier_t     component;
-} suit_component_with_index_t;
+    UsefulBufC                      encoded_component;
+} suit_encoded_component_with_index_t;
 
 /*
  * SUIT_Dependency
  */
 typedef struct suit_dependency_metadata {
-    suit_component_identifier_t     prefix;
+    UsefulBufC                      prefix;
     //TODO:                         $$SUIT_Dependency-extensions
 } suit_dependency_metadata_t;
 
@@ -639,7 +639,7 @@ typedef struct suit_text_component {
 } suit_text_component_t;
 
 typedef struct suit_text_component_pair {
-    suit_component_identifier_t     key;
+    UsefulBufC                      key;
     suit_text_component_t           text_component;
 } suit_text_component_pair_t;
 
@@ -718,11 +718,11 @@ typedef struct suit_unseverable_members {
  * SUIT_Common
  */
 typedef struct suit_common {
-    suit_dependencies_t             dependencies;
+    suit_dependencies_t                 dependencies;
 
-    uint8_t                         components_len;
-    suit_component_with_index_t     components[SUIT_MAX_INDEX_NUM];
-    suit_command_sequence_t         shared_seq;
+    uint8_t                             components_len;
+    suit_encoded_component_with_index_t components[SUIT_MAX_INDEX_NUM];
+    suit_command_sequence_t             shared_seq;
 } suit_common_t;
 
 typedef struct suit_delegation_chain {
@@ -747,7 +747,7 @@ typedef struct suit_manifest {
     uint64_t                            sequence_number;
     suit_common_t                       common;
     UsefulBufC                          reference_uri;
-    suit_component_identifier_t         manifest_component_id;
+    UsefulBufC                          encoded_manifest_component_id;
     suit_severable_manifest_members_t   sev_man_mem;
     suit_severable_members_digests_t    sev_mem_dig;
     suit_unseverable_members_t          unsev_mem;
@@ -813,21 +813,6 @@ typedef struct suit_wait_event {
     uint64_t                    day_of_week;
 } suit_wait_event_t;
 
-/*!
- *  \brief  Parameters to request wait event.
- *
- *  Used by suit_wait_callback().
- */
-typedef struct suit_wait_args {
-    suit_rep_policy_t report_policy;
-
-    /*! Destination SUIT_Component_Identifier */
-    suit_component_identifier_t dst;
-
-    /*! SUIT_Wait_Event */
-    UsefulBufC wait_info_buf;
-} suit_wait_args_t;
-
 suit_err_t suit_error_from_qcbor_error(QCBORError error);
 bool suit_qcbor_value_is_uint64(QCBORItem *item);
 bool suit_qcbor_value_is_uint32(QCBORItem *item);
@@ -854,17 +839,6 @@ suit_err_t suit_verify_item(QCBORDecodeContext *context,
                             QCBORItem *item,
                             suit_digest_t *digest);
 size_t suit_qcbor_calc_rollback(QCBORItem *item);
-
-suit_err_t suit_decode_component_identifiers_from_item(QCBORDecodeContext *context,
-                                                       QCBORItem *item,
-                                                       bool next,
-                                                       suit_component_identifier_t *identifier);
-
-suit_err_t suit_decode_components_from_item(QCBORDecodeContext *context,
-                                            QCBORItem *item,
-                                            bool next,
-                                            suit_component_with_index_t *components,
-                                            uint8_t *num);
 
 #ifdef __cplusplus
 }

--- a/inc/csuit/suit_manifest_decode.h
+++ b/inc/csuit/suit_manifest_decode.h
@@ -36,6 +36,17 @@ suit_err_t suit_decode_envelope(UsefulBufC buf,
                                 suit_envelope_t *envelope,
                                 suit_mechanism_t *mechanism);
 
+suit_err_t suit_decode_component_identifier_from_item(QCBORDecodeContext *context,
+                                                      QCBORItem *item,
+                                                      bool next,
+                                                      suit_component_identifier_t *component_identifier);
+
+suit_err_t suit_decode_components_from_item(QCBORDecodeContext *context,
+                                            QCBORItem *item,
+                                            bool next,
+                                            suit_encoded_component_with_index_t *components,
+                                            uint8_t *num);
+
 /*!
     \brief  Decode array of SUIT_Component_Identifier.
 
@@ -44,8 +55,8 @@ suit_err_t suit_decode_envelope(UsefulBufC buf,
 
     \return     This returns one of the error codes defined by \ref suit_err_t.
  */
-suit_err_t suit_decode_component_identifiers(UsefulBufC buf,
-                                             suit_component_identifier_t *identifier);
+suit_err_t suit_decode_component_identifier(UsefulBufC buf,
+                                            suit_component_identifier_t *identifier);
 
 /*!
     \brief  Decode bstr-wrapped command sequence.

--- a/inc/csuit/suit_manifest_print.h
+++ b/inc/csuit/suit_manifest_print.h
@@ -61,6 +61,7 @@ suit_err_t suit_print_bytestr(const uint8_t *bytes, size_t len);
 suit_err_t suit_print_suit_parameters_list(const suit_parameters_list_t *params_list, const uint32_t indent_space, const uint32_t indent_delta);
 suit_err_t suit_print_cmd_seq(const suit_command_sequence_t *cmd_seq, const uint32_t indent_space, const uint32_t indent_delta);
 suit_err_t suit_print_component_identifier(const suit_component_identifier_t *identifier);
+suit_err_t suit_print_encoded_component_identifier(UsefulBufC encoded_component);
 suit_err_t suit_print_digest(const suit_digest_t *digest, const uint32_t indent_space, const uint32_t indent_delta);
 
 suit_err_t suit_print_component_metadata(const suit_component_metadata_t *component_metadata,

--- a/inc/csuit/suit_manifest_process.h
+++ b/inc/csuit/suit_manifest_process.h
@@ -162,6 +162,7 @@ typedef struct suit_report_args {
     suit-directive-unlink and suit-directive-fetch (only for integrated payloads).
  */
 typedef struct suit_invoke_args {
+    UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
     suit_component_identifier_t component_identifier;
     /* basically byte-string value, so may not '\0' terminated */
     uint8_t args[SUIT_MAX_ARGS_LENGTH];
@@ -184,6 +185,10 @@ typedef enum suit_store_key {
    suit-directive-unlink and suit-directive-fetch (only for integrated payloads).
  */
 typedef struct suit_store_args {
+    UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
+    uint64_t manifest_sequence_number;
+    bool is_manifest_itself;
+
     suit_rep_policy_t report_policy;
 
     /*! Destination SUIT_Component_Identifier */
@@ -217,6 +222,9 @@ typedef struct suit_store_args {
  * Used on suit-directive-fetch.
  */
 typedef struct suit_fetch_args {
+    UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
+    uint64_t manifest_sequence_number;
+
     suit_rep_policy_t report_policy;
 
     /*! Destination SUIT_Component_Identifier */
@@ -276,6 +284,8 @@ typedef struct suit_callback_ret {
  *  \brief  Parameters to request checking condition.
  */
 typedef struct suit_condition_args {
+    UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
+
     suit_rep_policy_t report_policy;
 
     /*! Destination SUIT_Component_Identifier */
@@ -309,6 +319,19 @@ typedef struct suit_condition_args {
     You don't need to free it.
  */
 typedef struct suit_processor_context {
+    /*
+     * these fields should be backed up and recovered after dependency-resolution
+     */
+    struct suit_processor_context_backup {
+        UsefulBufC manifest;
+        UsefulBufC manifest_digest;
+        uint64_t manifest_sequence_number;
+        suit_parameter_args_t parameters[SUIT_MAX_INDEX_NUM];
+    } b;
+
+    /*
+     * following fields are shared in the dependency resolution context
+     */
     union {
         uint8_t status;
         struct {
@@ -328,10 +351,6 @@ typedef struct suit_processor_context {
 
     /* sections requested to process */
     suit_process_flag_t process_flags;
-
-    UsefulBufC manifest;
-    suit_digest_t expected_manifest_digest;
-    suit_parameter_args_t parameters[SUIT_MAX_INDEX_NUM];
 
     // size_t key_len;
     suit_mechanism_t mechanisms[SUIT_MAX_KEY_NUM];

--- a/inc/csuit/suit_manifest_process.h
+++ b/inc/csuit/suit_manifest_process.h
@@ -163,12 +163,11 @@ typedef struct suit_report_args {
  */
 typedef struct suit_invoke_args {
     UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
-    suit_component_identifier_t component_identifier;
+    UsefulBufC encoded_component_identifier;
+
     /* basically byte-string value, so may not '\0' terminated */
     uint8_t args[SUIT_MAX_ARGS_LENGTH];
     size_t args_len;
-
-    suit_rep_policy_t report_policy;
 } suit_invoke_args_t;
 
 typedef enum suit_store_key {
@@ -189,12 +188,10 @@ typedef struct suit_store_args {
     uint64_t manifest_sequence_number;
     bool is_manifest_itself;
 
-    suit_rep_policy_t report_policy;
-
-    /*! Destination SUIT_Component_Identifier */
-    suit_component_identifier_t dst;
+    /*! Destination encoded SUIT_Component_Identifier */
+    UsefulBufC dst;
     /*! Used if \ref operation is SUIT_COPY or SUIT_SWAP */
-    suit_component_identifier_t src;
+    UsefulBufC src;
     /*! Pointer and length to the content to be written */
     UsefulBufC src_buf;
 
@@ -225,10 +222,8 @@ typedef struct suit_fetch_args {
     UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
     uint64_t manifest_sequence_number;
 
-    suit_rep_policy_t report_policy;
-
-    /*! Destination SUIT_Component_Identifier */
-    suit_component_identifier_t dst;
+    /*! Destination encoded SUIT_Component_Identifier */
+    UsefulBufC dst;
     /*! Length of uri */
     size_t uri_len;
     /*! URI terminated with '\0' */
@@ -286,10 +281,8 @@ typedef struct suit_callback_ret {
 typedef struct suit_condition_args {
     UsefulBufC manifest_digest; // as an identifier of SUIT Manifests
 
-    suit_rep_policy_t report_policy;
-
-    /*! Destination SUIT_Component_Identifier */
-    suit_component_identifier_t dst;
+    /*! Destination encoded SUIT_Component_Identifier */
+    UsefulBufC dst;
 
     /*! suit-condition-* label */
     suit_con_dir_key_t condition;
@@ -297,6 +290,19 @@ typedef struct suit_condition_args {
     /*! To be expected values */
     suit_union_parameter_t expected;
 } suit_condition_args_t;
+
+/*!
+ *  \brief  Parameters to request wait event.
+ *
+ *  Used by suit_wait_callback().
+ */
+typedef struct suit_wait_args {
+    /*! Encoded destination SUIT_Component_Identifier */
+    UsefulBufC dst;
+
+    /*! SUIT_Wait_Event */
+    UsefulBufC wait_info_buf;
+} suit_wait_args_t;
 
 /*!
     \brief  A context for the SUIT Manifest Processor
@@ -363,7 +369,7 @@ typedef struct suit_processor_context {
     size_t section_offset;
     suit_con_dir_key_t condition_or_directive;
     uint8_t component_index;
-    const suit_component_identifier_t *component;
+    UsefulBufC encoded_component;
     // currently, up to two parameters are consumed by one callback
     suit_parameter_key_t parameter_keys[LIBCSUIT_MAX_REPORT_PRAMETER_NUM];
     suit_union_parameter_t parameter_value;
@@ -378,13 +384,13 @@ typedef struct suit_extracted {
     suit_dependencies_t dependencies;
 #endif
 #if !defined(LIBCSUIT_DISABLE_MANIFEST_COMPONENT_ID)
-    suit_component_identifier_t manifest_component_id;
+    UsefulBufC encoded_manifest_component_id;
 #endif
 #if !defined(LIBCSUIT_DISABLE_MANIFEST_SET_VERSION)
     suit_int64_array_t set_version;
 #endif
     uint8_t components_len;
-    suit_component_with_index_t components[SUIT_MAX_INDEX_NUM];
+    suit_encoded_component_with_index_t encoded_components[SUIT_MAX_INDEX_NUM];
     suit_payloads_t payloads;
 
     UsefulBufC manifest;

--- a/inc/csuit/suit_reporting_engine.h
+++ b/inc/csuit/suit_reporting_engine.h
@@ -16,6 +16,8 @@
 #include "qcbor/UsefulBuf.h"
 #include "qcbor/qcbor_encode.h"
 
+#define SUIT_MAX_DEPENDENCY_LENGTH 4
+
 #if defined(LIBCSUIT_USE_T_COSE_1)
 #include "t_cose/t_cose_common.h"
 #else
@@ -139,7 +141,7 @@ typedef enum suit_report_capability_report_key {
 
 typedef struct suit_manifest_tree {
     size_t      len;
-    uint8_t     manifest_index[SUIT_MAX_ARRAY_LENGTH];
+    uint8_t     manifest_index[SUIT_MAX_DEPENDENCY_LENGTH];
 } suit_manifest_tree_t;
 
 enum suit_report_state {
@@ -196,7 +198,7 @@ typedef struct suit_report_context {
 
     // temporal storage for the SUIT_Digest in the suit-authentication-wrapper.
     // NOTE: the actual memory should not be freed before calling suit_report_reference_uri().
-    suit_digest_t digest;
+    UsefulBufC manifest_digest;
 
     uint8_t current_index;
 
@@ -215,7 +217,7 @@ typedef struct suit_report_context {
  */
 suit_err_t suit_report_manifest_digest(
     suit_report_context_t *report_context,
-    suit_digest_t digest);
+    UsefulBufC digest);
 
 /*!
     \brief  This function should be called on suit-reference-uri.

--- a/inc/csuit/suit_reporting_engine.h
+++ b/inc/csuit/suit_reporting_engine.h
@@ -295,7 +295,7 @@ suit_err_t suit_report_extend_record(
 
     \param[in]  report_context  Pointer to the context of Repoting Engine
     \param[in]  component_index The Component Index in processing
-    \param[in]  component       Pointer to the \ref suit_component_identifier_t represents SUIT_Component_Identifier
+    \param[in]  component       Pointer and length to the encoded SUIT_Component_Identifier
     \param[in]  parameter_key   With parameter_value, this represents $$SUIT_Parameter
     \param[in]  parameter_value Pointer to the reported parameter value
 
@@ -304,7 +304,7 @@ suit_err_t suit_report_extend_record(
 suit_err_t suit_report_extend_system_property_claims(
     suit_report_context_t *report_context,
     const uint8_t component_index,
-    const suit_component_identifier_t *component,
+    UsefulBufC component,
     const suit_parameter_key_t parameter_keys[],
     const struct suit_union_parameter *parameter_value);
 

--- a/src/suit_common.c
+++ b/src/suit_common.c
@@ -147,16 +147,14 @@ suit_err_t suit_qcbor_get(QCBORDecodeContext *message,
 
 bool suit_qcbor_value_is_uint64(QCBORItem *item)
 {
-    if (item->uDataType == QCBOR_TYPE_INT64) {
-        if (item->val.int64 < 0) {
-            return false;
-        }
-        /* there is no need to cast int64_t [0, INT32_MAX] value into uint64_t in the union */
+    if (item->uDataType == QCBOR_TYPE_UINT64) {
+        return true;
     }
-    else if (item->uDataType != QCBOR_TYPE_UINT64) {
-        return false;
+    else if (item->uDataType == QCBOR_TYPE_INT64 && item->val.int64 >= 0) {
+        // can be casted with uint64_t
+        return true;
     }
-    return true;
+    return false;
 }
 
 bool suit_qcbor_value_is_uint32(QCBORItem *item)

--- a/src/suit_manifest_encode.c
+++ b/src/suit_manifest_encode.c
@@ -688,7 +688,7 @@ suit_err_t suit_encode_common(suit_encoder_context_t *encoder_context,
             const suit_dependency_t *dependency = &suit_common->dependencies.dependency[i];
             QCBOREncode_AddUInt64(&context, dependency->index);
             QCBOREncode_OpenMap(&context);
-            suit_encode_append_component_identifier(&dependency->dependency_metadata.prefix, SUIT_DEPENDENCY_PREFIX, &context);
+            QCBOREncode_AddEncodedToMapN(&context, SUIT_DEPENDENCY_PREFIX, dependency->dependency_metadata.prefix);
             //TODO: SUIT_Dependency-extensions
             QCBOREncode_CloseMap(&context);
         }
@@ -700,7 +700,7 @@ suit_err_t suit_encode_common(suit_encoder_context_t *encoder_context,
     if (suit_common->components_len > 0) {
         QCBOREncode_OpenArrayInMapN(&context, SUIT_COMPONENTS);
         for (size_t i = 0; i < suit_common->components_len; i++) {
-            suit_encode_append_component_identifier(&suit_common->components[i].component, 0, &context);
+            QCBOREncode_AddEncoded(&context, suit_common->components[i].encoded_component);
         }
         QCBOREncode_CloseArray(&context);
     }
@@ -751,12 +751,7 @@ suit_err_t suit_encoder_context_text_lmap(const suit_text_lmap_t *text,
 
     // SUIT_Component_Identifier : {}
     for (size_t i = 0; i < text->component_len; i++) {
-        const suit_component_identifier_t *component = &text->component[i].key;
-        QCBOREncode_OpenArray(context);
-        for (size_t j = 0; j < component->len; j++) {
-            QCBOREncode_AddBytes(context, (UsefulBufC){.ptr = component->identifier[j].ptr, .len = component->identifier[j].len});
-        }
-        QCBOREncode_CloseArray(context);
+        QCBOREncode_AddEncoded(context, text->component[i].key);
         QCBOREncode_OpenMap(context);
         const suit_text_component_t *text_component = &text->component[i].text_component;
         if (text_component->vendor_name.len > 0) {
@@ -1089,15 +1084,15 @@ suit_err_t suit_encode_manifest(suit_encoder_context_t *encoder_context,
 
     // 4
 #if !defined(LIBCSUIT_DISABLE_MANIFEST_REFERENCE_URI)
-    if (manifest->reference_uri.len > 0) {
+    if (!UsefulBuf_IsNULLOrEmptyC(manifest->reference_uri)) {
         QCBOREncode_AddTextToMapN(&context, SUIT_REFERENCE_URI, (UsefulBufC){.ptr = manifest->reference_uri.ptr, .len = manifest->reference_uri.len});
     }
 #endif /* !LIBCSUIT_DISABLE_MANIFEST_REFERENCE_URI */
 
     // 5
 #if !defined(LIBCSUIT_DISABLE_MANIFEST_COMPONENT_ID)
-    if (manifest->manifest_component_id.len > 0) {
-        suit_encode_append_component_identifier(&manifest->manifest_component_id, SUIT_MANIFEST_COMPONENT_ID, &context);
+    if (!UsefulBuf_IsNULLOrEmptyC(manifest->encoded_manifest_component_id)) {
+        QCBOREncode_AddEncodedToMapN(&context, SUIT_MANIFEST_COMPONENT_ID, manifest->encoded_manifest_component_id);
     }
 #endif /* !LIBCSUIT_DISABLE_MANIFEST_COMPONENT_ID */
 

--- a/src/suit_manifest_process.c
+++ b/src/suit_manifest_process.c
@@ -1638,16 +1638,14 @@ suit_err_t suit_process_dependency(suit_processor_context_t *processor_context,
         }
 
         // backup several contexts
-        UsefulBufC manifest_backup = processor_context->b.manifest;
-        UsefulBufC manifest_digest_backup = processor_context->b.manifest_digest;
-        suit_process_flag_t process_flags_backup = processor_context->process_flags;
+        struct suit_processor_context_backup backup = processor_context->b;
 
         // OK, let's dive into the dependency manifest
         processor_context->dependency_tree.manifest_index[processor_context->dependency_tree.len] = processor_context->component_index;
         processor_context->dependency_tree.len++;
         processor_context->b.manifest = payload->bytes;
         processor_context->b.manifest_digest = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
-        // checks only suit-delegation and suit-authentication-wrapper
+        // checks corresponding section of the manifest
         processor_context->process_flags = suit_manifest_key_to_process_flag(processor_context->manifest_key);
 
         /*
@@ -1658,10 +1656,7 @@ suit_err_t suit_process_dependency(suit_processor_context_t *processor_context,
         result = suit_process_envelope(processor_context);
 
         // recover the context
-        processor_context->process_flags = process_flags_backup;
-        processor_context->b.manifest_digest = manifest_digest_backup;
-        processor_context->b.manifest = manifest_backup;
-        processor_context->dependency_tree.len--;
+        processor_context->b = backup;
 
 report:
 #if !defined(LIBCSUIT_DISABLE_SUIT_REPORT)

--- a/src/suit_manifest_process.c
+++ b/src/suit_manifest_process.c
@@ -61,9 +61,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
              QCBORDecode_GetInt64(context, &val.i64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY;
-                    processor_context->parameters[processor_context->component_index].update_priority = val.i64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY;
+                    processor_context->b.parameters[processor_context->component_index].update_priority = val.i64;
                 }
             }
             break;
@@ -74,9 +74,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetUInt64(context, &val.u64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_SIZE;
-                    processor_context->parameters[processor_context->component_index].image_size = val.u64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_SIZE;
+                    processor_context->b.parameters[processor_context->component_index].image_size = val.u64;
                 }
             }
             break;
@@ -85,9 +85,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetUInt64(context, &val.u64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT;
-                    processor_context->parameters[processor_context->component_index].source_component = val.u64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT;
+                    processor_context->b.parameters[processor_context->component_index].source_component = val.u64;
                 }
             }
             break;
@@ -98,9 +98,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetUInt64(context, &val.u64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT;
-                    processor_context->parameters[processor_context->component_index].component_slot = val.u64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT;
+                    processor_context->b.parameters[processor_context->component_index].component_slot = val.u64;
                 }
             }
             break;
@@ -111,9 +111,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetUInt64(context, &val.u64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_USE_BEFORE;
-                    processor_context->parameters[processor_context->component_index].use_before = val.u64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_USE_BEFORE;
+                    processor_context->b.parameters[processor_context->component_index].use_before = val.u64;
                 }
             }
             break;
@@ -124,9 +124,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
              QCBORDecode_GetUInt64(context, &val.u64);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY;
-                    processor_context->parameters[processor_context->component_index].minimum_battery = val.u64;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY;
+                    processor_context->b.parameters[processor_context->component_index].minimum_battery = val.u64;
                 }
             }
             break;
@@ -142,9 +142,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetBool(context, &val.b);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_SOFT_FAILURE) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOFT_FAILURE;
-                    processor_context->parameters[processor_context->component_index].soft_failure = (val.b) ? SUIT_PARAMETER_TRUE : SUIT_PARAMETER_FALSE;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_SOFT_FAILURE) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOFT_FAILURE;
+                    processor_context->b.parameters[processor_context->component_index].soft_failure = (val.b) ? SUIT_PARAMETER_TRUE : SUIT_PARAMETER_FALSE;
                 }
             }
             break;
@@ -155,9 +155,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetBool(context, &val.b);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_STRICT_ORDER) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_STRICT_ORDER;
-                    processor_context->parameters[processor_context->component_index].strict_order = (val.b) ? SUIT_PARAMETER_TRUE : SUIT_PARAMETER_FALSE;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_STRICT_ORDER) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_STRICT_ORDER;
+                    processor_context->b.parameters[processor_context->component_index].strict_order = (val.b) ? SUIT_PARAMETER_TRUE : SUIT_PARAMETER_FALSE;
                 }
             }
             break;
@@ -173,10 +173,10 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             }
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_URI) ||
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_URI) ||
                     directive == SUIT_DIRECTIVE_OVERRIDE_PARAMETERS) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_URI;
-                    processor_context->parameters[processor_context->component_index].uri = val.str;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_URI;
+                    processor_context->b.parameters[processor_context->component_index].uri = val.str;
                 }
             }
             break;
@@ -187,9 +187,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].vendor_id = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].vendor_id = val.str;
                 }
             }
             break;
@@ -199,9 +199,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].class_id = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].class_id = val.str;
                 }
             }
             break;
@@ -212,9 +212,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].device_id = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].device_id = val.str;
                 }
             }
             break;
@@ -225,9 +225,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CONTENT;
-                    processor_context->parameters[processor_context->component_index].content = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CONTENT;
+                    processor_context->b.parameters[processor_context->component_index].content = val.str;
                 }
             }
             break;
@@ -238,9 +238,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_INVOKE_ARGS) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_INVOKE_ARGS;
-                    processor_context->parameters[processor_context->component_index].invoke_args = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_INVOKE_ARGS) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_INVOKE_ARGS;
+                    processor_context->b.parameters[processor_context->component_index].invoke_args = val.str;
                 }
             }
             break;
@@ -251,9 +251,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_FETCH_ARGS;
-                    processor_context->parameters[processor_context->component_index].fetch_args = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_FETCH_ARGS;
+                    processor_context->b.parameters[processor_context->component_index].fetch_args = val.str;
                 }
             }
             break;
@@ -265,9 +265,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO;
-                    processor_context->parameters[processor_context->component_index].encryption_info = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO;
+                    processor_context->b.parameters[processor_context->component_index].encryption_info = val.str;
                 }
             }
             break;
@@ -278,9 +278,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST;
-                    processor_context->parameters[processor_context->component_index].image_digest_buf = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST;
+                    processor_context->b.parameters[processor_context->component_index].image_digest_buf = val.str;
                 }
             }
             break;
@@ -295,9 +295,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             if (result == SUIT_SUCCESS) {
                 for (size_t j = 0; j < suit_index->len; j++) {
                     processor_context->component_index = suit_index->index[j];
-                    if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VERSION) || override) {
-                        processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VERSION;
-                        processor_context->parameters[processor_context->component_index].version_match_buf = val.str;
+                    if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VERSION) || override) {
+                        processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VERSION;
+                        processor_context->b.parameters[processor_context->component_index].version_match_buf = val.str;
                     }
                 }
             }
@@ -310,9 +310,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_WAIT_INFO;
-                    processor_context->parameters[processor_context->component_index].wait_info_buf = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_WAIT_INFO;
+                    processor_context->b.parameters[processor_context->component_index].wait_info_buf = val.str;
                 }
             }
             break;
@@ -324,9 +324,9 @@ suit_err_t suit_set_parameters(suit_processor_context_t *processor_context,
             QCBORDecode_GetByteString(context, &val.str);
             for (size_t j = 0; j < suit_index->len; j++) {
                 processor_context->component_index = suit_index->index[j];
-                if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) || override) {
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA;
-                    processor_context->parameters[processor_context->component_index].component_metadata_buf = val.str;
+                if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) || override) {
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA;
+                    processor_context->b.parameters[processor_context->component_index].component_metadata_buf = val.str;
                 }
             }
             break;
@@ -505,9 +505,6 @@ suit_process_flag_t suit_manifest_key_to_process_flag(const suit_manifest_key_t 
 {
     suit_process_flag_t result = {0};
     switch (key) {
-    case SUIT_MANIFEST_COMPONENT_ID:
-        result.manifest_component_id = 1;
-        break;
     case SUIT_VALIDATE:
         result.validate = 1;
         break;
@@ -549,92 +546,92 @@ void suit_set_consumed_parameters(suit_processor_context_t *processor_context,
         switch (ret->consumed_parameter_keys[0]) {
         /* int */
         case SUIT_PARAMETER_UPDATE_PRIORITY:
-            processor_context->parameter_value.i64 = processor_context->parameters[processor_context->component_index].update_priority;
+            processor_context->parameter_value.i64 = processor_context->b.parameters[processor_context->component_index].update_priority;
             break;
         /* uint */
         case SUIT_PARAMETER_IMAGE_SIZE:
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].image_size;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].image_size;
             if (ret->consumed_parameter_keys[1] == SUIT_PARAMETER_IMAGE_DIGEST) {
                 processor_context->parameter_keys[1] = SUIT_PARAMETER_IMAGE_DIGEST;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].image_digest_buf;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
             }
             break;
         case SUIT_PARAMETER_COMPONENT_SLOT:
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].component_slot;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].component_slot;
             break;
         case SUIT_PARAMETER_SOURCE_COMPONENT:
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].source_component;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].source_component;
             if (ret->consumed_parameter_keys[1] == SUIT_PARAMETER_ENCRYPTION_INFO) {
                 processor_context->parameter_keys[1] = SUIT_PARAMETER_ENCRYPTION_INFO;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].encryption_info;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].encryption_info;
             }
             break;
         case SUIT_PARAMETER_USE_BEFORE:
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].use_before;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].use_before;
             break;
         case SUIT_PARAMETER_MINIMUM_BATTERY:
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].minimum_battery;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].minimum_battery;
             break;
         /* tstr */
         case SUIT_PARAMETER_URI:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].uri;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].uri;
             break;
         /* bstr */
         case SUIT_PARAMETER_VENDOR_IDENTIFIER:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].vendor_id;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].vendor_id;
             break;
         case SUIT_PARAMETER_CLASS_IDENTIFIER:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].class_id;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].class_id;
             break;
         case SUIT_PARAMETER_DEVICE_IDENTIFIER:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].device_id;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].device_id;
             break;
         case SUIT_PARAMETER_CONTENT:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].content;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].content;
             break;
         case SUIT_PARAMETER_INVOKE_ARGS:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].invoke_args;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].invoke_args;
             break;
         case SUIT_PARAMETER_FETCH_ARGS:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].fetch_args;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].fetch_args;
             break;
         
         /* bstr .cbor SUIT_Digest */
         case SUIT_PARAMETER_IMAGE_DIGEST:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].image_digest_buf;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
             if (ret->consumed_parameter_keys[1] == SUIT_PARAMETER_IMAGE_SIZE) {
                 processor_context->parameter_keys[1] = SUIT_PARAMETER_IMAGE_SIZE;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].image_size;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].image_size;
             }
             break;
         /* bstr .cbor SUIT_Encryption_Info */
         case SUIT_PARAMETER_ENCRYPTION_INFO:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].encryption_info;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].encryption_info;
             if (ret->consumed_parameter_keys[1] == SUIT_PARAMETER_SOURCE_COMPONENT) {
                 processor_context->parameter_keys[1] = SUIT_PARAMETER_SOURCE_COMPONENT;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].source_component;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].source_component;
             }
             break;
 
         /* bstr .cbor SUIT_Parameter_Version_Match */
         case SUIT_PARAMETER_VERSION:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].version_match_buf;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].version_match_buf;
             break;
         /* bstr .cbor SUIT_Wait_Event */
         case SUIT_PARAMETER_WAIT_INFO:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].wait_info_buf;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].wait_info_buf;
             break;
         /* bstr .cbor SUIT_Component_Metadata */
         case SUIT_PARAMETER_COMPONENT_METADATA:
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].component_metadata_buf;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].component_metadata_buf;
             break;
 
         /* bool */
         case SUIT_PARAMETER_STRICT_ORDER:
-            processor_context->parameter_value.b = processor_context->parameters[processor_context->component_index].strict_order;
+            processor_context->parameter_value.b = processor_context->b.parameters[processor_context->component_index].strict_order;
             break;
         case SUIT_PARAMETER_SOFT_FAILURE:
-            processor_context->parameter_value.b = processor_context->parameters[processor_context->component_index].soft_failure;
+            processor_context->parameter_value.b = processor_context->b.parameters[processor_context->component_index].soft_failure;
             break;
 
         case SUIT_PARAMETER_INVALID:
@@ -653,7 +650,7 @@ suit_err_t suit_process_fetch(suit_processor_context_t *processor_context,
 
     for (size_t i = 0; i < suit_index->len; i++) {
         processor_context->component_index = suit_index->index[i];
-        if (processor_context->parameters[processor_context->component_index].uri.len >= SUIT_MAX_NAME_LENGTH) {
+        if (processor_context->b.parameters[processor_context->component_index].uri.len >= SUIT_MAX_NAME_LENGTH) {
             return SUIT_ERR_NO_MEMORY;
         }
         processor_context->component = suit_index_to_component_identifier(extracted, processor_context->component_index);
@@ -661,35 +658,38 @@ suit_err_t suit_process_fetch(suit_processor_context_t *processor_context,
             return SUIT_ERR_COMPONENT_NOT_FOUND;
         }
 
-        processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].uri;
-        suit_payload_t *payload = suit_key_to_payload(extracted, processor_context->parameters[processor_context->component_index].uri);
+        processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].uri;
+        suit_payload_t *payload = suit_key_to_payload(extracted, processor_context->b.parameters[processor_context->component_index].uri);
         if (payload == NULL) {
             if (extracted->payloads.len >= SUIT_MAX_ARRAY_LENGTH) {
                 return SUIT_ERR_NO_MEMORY;
             }
-            size_t buf_size = (processor_context->parameters[processor_context->component_index].image_size > 0) ? processor_context->parameters[processor_context->component_index].image_size : processor_context->left_len;
+            size_t buf_size = (processor_context->b.parameters[processor_context->component_index].image_size > 0) ? processor_context->b.parameters[processor_context->component_index].image_size : processor_context->left_len;
             if (buf_size > processor_context->left_len) {
                 return SUIT_ERR_NO_MEMORY;
             }
 
             suit_fetch_args_t fetch = {0};
             suit_callback_ret_t fret = {0};
+            fetch.manifest_digest = processor_context->b.manifest_digest;
+            fetch.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+
             fetch.dst = *processor_context->component;
 
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
-                fetch.encryption_info = processor_context->parameters[processor_context->component_index].encryption_info;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
+                fetch.encryption_info = processor_context->b.parameters[processor_context->component_index].encryption_info;
                 memcpy(fetch.mechanisms, processor_context->mechanisms, sizeof(fetch.mechanisms));
             }
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
-                fetch.component_metadata_buf = processor_context->parameters[processor_context->component_index].component_metadata_buf;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
+                fetch.component_metadata_buf = processor_context->b.parameters[processor_context->component_index].component_metadata_buf;
             }
 
             /* the size of uri is already checked at suit-directive-override-parameters */
-            memcpy(fetch.uri, processor_context->parameters[processor_context->component_index].uri.ptr, processor_context->parameters[processor_context->component_index].uri.len);
-            fetch.uri[processor_context->parameters[processor_context->component_index].uri.len] = '\0';
-            fetch.uri_len = processor_context->parameters[processor_context->component_index].uri.len + 1;
+            memcpy(fetch.uri, processor_context->b.parameters[processor_context->component_index].uri.ptr, processor_context->b.parameters[processor_context->component_index].uri.len);
+            fetch.uri[processor_context->b.parameters[processor_context->component_index].uri.len] = '\0';
+            fetch.uri_len = processor_context->b.parameters[processor_context->component_index].uri.len + 1;
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS)
-            fetch.args = processor_context->parameters[processor_context->component_index].fetch_args;
+            fetch.args = processor_context->b.parameters[processor_context->component_index].fetch_args;
 #endif /* LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS */
             fetch.buf_len = buf_size;
             fetch.ptr = (uint8_t *)processor_context->allocated.ptr + (processor_context->allocated.len - processor_context->left_len);
@@ -715,27 +715,31 @@ suit_err_t suit_process_fetch(suit_processor_context_t *processor_context,
             payload->bytes.ptr = fetch.ptr;
             payload->bytes.len = fret.buf_len;
 
-            payload->key = processor_context->parameters[processor_context->component_index].uri;
+            payload->key = processor_context->b.parameters[processor_context->component_index].uri;
             payload->index = processor_context->component_index;
         }
         else {
             /* already handled with integrated-payload or integrated-dependency */
             suit_store_args_t store = {0};
+            store.manifest_digest = processor_context->b.manifest_digest;
+            store.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+            store.is_manifest_itself = false;
+
             store.report_policy = report_policy;
             store.dst = *processor_context->component;
             store.src_buf = payload->bytes;
             store.operation = SUIT_STORE;
             suit_callback_ret_t ret = {0};
 
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
-                store.encryption_info = processor_context->parameters[processor_context->component_index].encryption_info;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
+                store.encryption_info = processor_context->b.parameters[processor_context->component_index].encryption_info;
             }
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
-                store.component_metadata_buf = processor_context->parameters[processor_context->component_index].component_metadata_buf;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
+                store.component_metadata_buf = processor_context->b.parameters[processor_context->component_index].component_metadata_buf;
             }
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS)
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS) {
-                store.fetch_args = processor_context->parameters[processor_context->component_index].fetch_args;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS) {
+                store.fetch_args = processor_context->b.parameters[processor_context->component_index].fetch_args;
             }
 #endif /* LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS */
             result = suit_store_callback(store, &ret);
@@ -745,7 +749,7 @@ suit_err_t suit_process_fetch(suit_processor_context_t *processor_context,
             if (result != SUIT_SUCCESS) {
                 return result;
             }
-            payload->key = processor_context->parameters[processor_context->component_index].uri;
+            payload->key = processor_context->b.parameters[processor_context->component_index].uri;
             payload->index = processor_context->component_index;
         }
     }
@@ -775,11 +779,11 @@ suit_err_t suit_process_invoke(suit_processor_context_t *processor_context,
         suit_invoke_args_t invoke = {0};
         invoke.report_policy = report_policy;
         invoke.component_identifier = *processor_context->component;
-        invoke.args_len = processor_context->parameters[processor_context->component_index].invoke_args.len;
+        invoke.args_len = processor_context->b.parameters[processor_context->component_index].invoke_args.len;
         if (invoke.args_len > 0) {
-            memcpy(invoke.args, processor_context->parameters[processor_context->component_index].invoke_args.ptr, invoke.args_len);
+            memcpy(invoke.args, processor_context->b.parameters[processor_context->component_index].invoke_args.ptr, invoke.args_len);
             processor_context->parameter_keys[0] = SUIT_PARAMETER_INVOKE_ARGS;
-            processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].invoke_args;
+            processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].invoke_args;
         }
 
 #if !defined(LIBCSUIT_DISABLE_SUIT_REPORT)
@@ -830,6 +834,7 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
                                   suit_rep_policy_t report_policy)
 {
     suit_err_t result = SUIT_SUCCESS;
+    struct suit_processor_context_backup backup;
 
     for (uint8_t i = 0; i < suit_index->len; i++) {
         processor_context->component_index = suit_index->index[i];
@@ -837,11 +842,12 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
         memset(&processor_context->parameter_keys, 0, sizeof(processor_context->parameter_keys));
 
         bool callback_required = true;
-        suit_condition_args_t args = {0};
         processor_context->component = suit_index_to_component_identifier(extracted, processor_context->component_index);
         if (processor_context->component == NULL) {
             return SUIT_ERR_COMPONENT_NOT_FOUND;
         }
+        suit_condition_args_t args = {0};
+        args.manifest_digest = processor_context->b.manifest_digest;
         args.dst = *processor_context->component;
         args.condition = processor_context->condition_or_directive;
 
@@ -849,9 +855,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
         /* uint64 */
 #if !defined(LIBCSUIT_DISABLE_CONDITION_COMPONENT_SLOT)
         case SUIT_CONDITION_COMPONENT_SLOT:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT) {
-                args.expected.u64 = processor_context->parameters[processor_context->component_index].component_slot;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].component_slot;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT) {
+                args.expected.u64 = processor_context->b.parameters[processor_context->component_index].component_slot;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].component_slot;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -861,9 +867,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_USE_BEFORE)
         case SUIT_CONDITION_USE_BEFORE:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE) {
-                args.expected.u64 = processor_context->parameters[processor_context->component_index].use_before;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].use_before;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE) {
+                args.expected.u64 = processor_context->b.parameters[processor_context->component_index].use_before;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].use_before;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -873,9 +879,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_MINIMUM_BATTERY)
         case SUIT_CONDITION_MINIMUM_BATTERY:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY) {
-                args.expected.u64 = processor_context->parameters[processor_context->component_index].minimum_battery;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].minimum_battery;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY) {
+                args.expected.u64 = processor_context->b.parameters[processor_context->component_index].minimum_battery;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].minimum_battery;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -885,9 +891,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_UPDATE_AUTHORIZED)
         case SUIT_CONDITION_UPDATE_AUTHORIZED:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY) {
-                args.expected.i64 = processor_context->parameters[processor_context->component_index].update_priority;
-                processor_context->parameter_value.i64 = processor_context->parameters[processor_context->component_index].update_priority;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY) {
+                args.expected.i64 = processor_context->b.parameters[processor_context->component_index].update_priority;
+                processor_context->parameter_value.i64 = processor_context->b.parameters[processor_context->component_index].update_priority;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -897,9 +903,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
         /* bstr */
         case SUIT_CONDITION_VENDOR_IDENTIFIER:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].vendor_id;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].vendor_id;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].vendor_id;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].vendor_id;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -908,9 +914,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_CLASS_IDENTIFIER)
         case SUIT_CONDITION_CLASS_IDENTIFIER:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].class_id;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].class_id;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].class_id;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].class_id;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -920,9 +926,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_DEVICE_IDENTIFIER)
         case SUIT_CONDITION_DEVICE_IDENTIFIER:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].device_id;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].device_id;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].device_id;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].device_id;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -932,9 +938,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_CHECK_CONTENT)
         case SUIT_CONDITION_CHECK_CONTENT:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].content;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].content;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].content;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].content;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -947,13 +953,13 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 #if !defined(LIBCSUIT_DISABLE_CONDITION_IMAGE_NOT_MATCH)
         case SUIT_CONDITION_IMAGE_NOT_MATCH:
 #endif
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE) {
-                args.expected.u64 = processor_context->parameters[processor_context->component_index].image_size;
-                processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].image_size;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE) {
+                args.expected.u64 = processor_context->b.parameters[processor_context->component_index].image_size;
+                processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].image_size;
             }
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].image_digest_buf;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].image_digest_buf;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -963,9 +969,9 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
         /* draft-ietf-suit-trust-domains */
 #if !defined(LIBCSUIT_DISABLE_CONDITION_VERSION)
         case SUIT_CONDITION_VERSION:
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VERSION) {
-                args.expected.str = processor_context->parameters[processor_context->component_index].version_match_buf;
-                processor_context->parameter_value.str = processor_context->parameters[processor_context->component_index].version_match_buf;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_VERSION) {
+                args.expected.str = processor_context->b.parameters[processor_context->component_index].version_match_buf;
+                processor_context->parameter_value.str = processor_context->b.parameters[processor_context->component_index].version_match_buf;
             }
             else {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
@@ -975,13 +981,16 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
 
 #if !defined(LIBCSUIT_DISABLE_CONDITION_DEPENDENCY_INTEGRITY)
         case SUIT_CONDITION_DEPENDENCY_INTEGRITY:
+            if (processor_context->dependency_tree.len + 1 >= SUIT_MAX_DEPENDENCY_LENGTH) {
+                return SUIT_ERR_NO_MEMORY;
+            }
             callback_required = false;
             result = suit_index_is_dependency(extracted, processor_context->component_index);
             if (result != SUIT_SUCCESS) {
                 return result;
             }
 
-            if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST)) {
+            if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST)) {
                 return SUIT_ERR_PARAMETER_NOT_FOUND;
             }
             suit_payload_t *payload = suit_index_to_payload(extracted, processor_context->component_index);
@@ -989,28 +998,22 @@ suit_err_t suit_process_condition(suit_processor_context_t *processor_context,
                 return SUIT_ERR_COMPONENT_NOT_FOUND;
             }
 
+            // backup several contexts
+            backup = processor_context->b;
+
             // OK, let's dive into the dependency manifest
             processor_context->dependency_tree.manifest_index[processor_context->dependency_tree.len] = processor_context->component_index;
             processor_context->dependency_tree.len++;
-            result = suit_decode_digest(processor_context->parameters[processor_context->component_index].image_digest_buf, &processor_context->expected_manifest_digest);
-            if (result != SUIT_SUCCESS) {
-                processor_context->reason = SUIT_REPORT_REASON_CBOR_PARSE;
-                return result;
-            }
-
-            UsefulBufC manifest_backup = processor_context->manifest;
-            processor_context->manifest = payload->bytes;
-
+            processor_context->b.manifest = payload->bytes;
+            processor_context->b.manifest_digest = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
+            memset(processor_context->b.parameters, 0, sizeof(processor_context->b.parameters));
             // checks only suit-delegation and suit-authentication-wrapper
-            suit_process_flag_t process_flags_backup = processor_context->process_flags;
             processor_context->process_flags.all = 0;
 
             result = suit_process_envelope(processor_context);
 
             // recover the context
-            processor_context->process_flags = process_flags_backup;
-            processor_context->manifest = manifest_backup;
-            processor_context->expected_manifest_digest.algorithm_id = 0;
+            processor_context->b = backup;
             processor_context->dependency_tree.len--;
             break;
 
@@ -1092,7 +1095,7 @@ suit_err_t suit_process_wait(suit_processor_context_t *processor_context,
         processor_context->component_index = suit_index->index[i];
 
         suit_wait_args_t wait_args = {0};
-        if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO)) {
+        if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO)) {
             return SUIT_ERR_PARAMETER_NOT_FOUND;
         }
         processor_context->component = suit_index_to_component_identifier(extracted, processor_context->component_index);
@@ -1100,7 +1103,7 @@ suit_err_t suit_process_wait(suit_processor_context_t *processor_context,
             return SUIT_ERR_COMPONENT_NOT_FOUND;
         }
         wait_args.dst = *processor_context->component;
-        wait_args.wait_info_buf = processor_context->parameters[processor_context->component_index].wait_info_buf;
+        wait_args.wait_info_buf = processor_context->b.parameters[processor_context->component_index].wait_info_buf;
         wait_args.report_policy = report_policy;
 
         result = suit_wait_callback(wait_args);
@@ -1122,18 +1125,22 @@ suit_err_t suit_process_write(suit_processor_context_t *processor_context,
         processor_context->component_index = suit_index->index[i];
 
         suit_store_args_t store = {0};
-        if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT)) {
+        store.manifest_digest = processor_context->b.manifest_digest;
+        store.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+        store.is_manifest_itself = false;
+
+        store.report_policy = report_policy;
+        if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT)) {
             return SUIT_ERR_PARAMETER_NOT_FOUND;
         }
-        store.src_buf = processor_context->parameters[processor_context->component_index].content;
-        if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
-            store.encryption_info = processor_context->parameters[processor_context->component_index].encryption_info;
+        store.src_buf = processor_context->b.parameters[processor_context->component_index].content;
+        if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
+            store.encryption_info = processor_context->b.parameters[processor_context->component_index].encryption_info;
             memcpy(store.mechanisms, processor_context->mechanisms, sizeof(store.mechanisms));
         }
-        if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
-            store.component_metadata_buf = processor_context->parameters[processor_context->component_index].component_metadata_buf;
+        if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA) {
+            store.component_metadata_buf = processor_context->b.parameters[processor_context->component_index].component_metadata_buf;
         }
-        store.report_policy = report_policy;
         processor_context->component = suit_index_to_component_identifier(extracted, processor_context->component_index);
         if (processor_context->component == NULL) {
             return SUIT_ERR_COMPONENT_NOT_FOUND;
@@ -1164,6 +1171,10 @@ suit_err_t suit_process_copy_swap(suit_processor_context_t *processor_context,
         processor_context->component_index = suit_index->index[i];
 
         suit_store_args_t store = {0};
+        store.manifest_digest = processor_context->b.manifest_digest;
+        store.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+        store.is_manifest_itself = false;
+
         store.report_policy = report_policy;
 
         if (is_swap) {
@@ -1171,8 +1182,8 @@ suit_err_t suit_process_copy_swap(suit_processor_context_t *processor_context,
         }
         else {
             store.operation = SUIT_COPY;
-            if (processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
-                store.encryption_info = processor_context->parameters[processor_context->component_index].encryption_info;
+            if (processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO) {
+                store.encryption_info = processor_context->b.parameters[processor_context->component_index].encryption_info;
                 for (size_t j = 0; j < SUIT_MAX_KEY_NUM; j++) {
                     if (processor_context->mechanisms[j].use &&
                         (processor_context->mechanisms[j].cose_tag == CBOR_TAG_COSE_ENCRYPT ||
@@ -1183,7 +1194,7 @@ suit_err_t suit_process_copy_swap(suit_processor_context_t *processor_context,
             }
         }
 
-        processor_context->component = suit_index_to_component_identifier(extracted, processor_context->parameters[processor_context->component_index].source_component);
+        processor_context->component = suit_index_to_component_identifier(extracted, processor_context->b.parameters[processor_context->component_index].source_component);
         if (processor_context->component == NULL) {
             return SUIT_ERR_COMPONENT_NOT_FOUND;
         }
@@ -1199,7 +1210,7 @@ suit_err_t suit_process_copy_swap(suit_processor_context_t *processor_context,
         processor_context->reason = ret.reason;
         if (ret.on_src) {
             processor_context->parameter_keys[0] = SUIT_PARAMETER_SOURCE_COMPONENT;
-            processor_context->parameter_value.u64 = processor_context->parameters[processor_context->component_index].source_component;
+            processor_context->parameter_value.u64 = processor_context->b.parameters[processor_context->component_index].source_component;
         }
         if (result != SUIT_SUCCESS) {
             if (result == SUIT_ERR_FAILED_TO_DECRYPT) {
@@ -1227,6 +1238,10 @@ suit_err_t suit_process_unlink(suit_processor_context_t *processor_context,
             return SUIT_ERR_COMPONENT_NOT_FOUND;
         }
         suit_store_args_t store = {0};
+        store.manifest_digest = processor_context->b.manifest_digest;
+        store.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+        store.is_manifest_itself = false;
+
         store.report_policy = report_policy;
         store.dst = *processor_context->component;
         store.operation = SUIT_UNLINK;
@@ -1267,10 +1282,10 @@ suit_err_t suit_process_run_sequence(suit_processor_context_t *processor_context
         tmp_suit_index.index[0] = suit_index->index[i];
 
         // soft-failure is false by default in run-sequence
-        processor_context->parameters[suit_index->index[i]].soft_failure = false;
+        processor_context->b.parameters[suit_index->index[i]].soft_failure = false;
 
         suit_err_t result = suit_process_command_sequence_buf(processor_context, extracted, buf, &tmp_suit_index, true);
-        if (result != SUIT_SUCCESS && !processor_context->parameters[suit_index->index[i]].soft_failure) {
+        if (result != SUIT_SUCCESS && !processor_context->b.parameters[suit_index->index[i]].soft_failure) {
             return result;
         }
     }
@@ -1315,14 +1330,14 @@ suit_err_t suit_process_try_each(suit_processor_context_t *processor_context,
                     tmp_suit_index.index[0] = suit_index->index[j];
 
                     // soft-failure is true by default in try-each
-                    processor_context->parameters[suit_index->index[j]].soft_failure = true;
+                    processor_context->b.parameters[suit_index->index[j]].soft_failure = true;
 
                     result = suit_process_command_sequence_buf(processor_context, extracted, item.val.string, &tmp_suit_index, true);
                     if (result == SUIT_SUCCESS) {
                         done_any = true;
                         done = true;
                     }
-                    else if (!processor_context->parameters[suit_index->index[j]].soft_failure) {
+                    else if (!processor_context->b.parameters[suit_index->index[j]].soft_failure) {
                         return SUIT_ERR_TRY_OUT;
                     }
                 }
@@ -1383,204 +1398,204 @@ suit_err_t suit_process_copy_params(suit_processor_context_t *processor_context,
                 /* int64 */
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_UPDATE_PRIORITY)
                 case SUIT_PARAMETER_UPDATE_PRIORITY:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY;
-                    processor_context->parameters[processor_context->component_index].update_priority = processor_context->parameters[src_index].update_priority;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_UPDATE_PRIORITY;
+                    processor_context->b.parameters[processor_context->component_index].update_priority = processor_context->b.parameters[src_index].update_priority;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_UPDATE_PRIORITY */
 
                 /* uint64 */
                 case SUIT_PARAMETER_IMAGE_SIZE:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_IMAGE_SIZE)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_SIZE;
-                    processor_context->parameters[processor_context->component_index].image_size = processor_context->parameters[src_index].image_size;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_SIZE;
+                    processor_context->b.parameters[processor_context->component_index].image_size = processor_context->b.parameters[src_index].image_size;
                     break;
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_SOURCE_COMPONENT)
                 case SUIT_PARAMETER_SOURCE_COMPONENT:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT;
-                    processor_context->parameters[processor_context->component_index].source_component = processor_context->parameters[src_index].source_component;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOURCE_COMPONENT;
+                    processor_context->b.parameters[processor_context->component_index].source_component = processor_context->b.parameters[src_index].source_component;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_SOURCE_COMPONENT */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_COMPONENT_SLOT)
                 case SUIT_PARAMETER_COMPONENT_SLOT:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT;
-                    processor_context->parameters[processor_context->component_index].component_slot = processor_context->parameters[src_index].component_slot;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_SLOT;
+                    processor_context->b.parameters[processor_context->component_index].component_slot = processor_context->b.parameters[src_index].component_slot;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_COMPONENT_SLOT */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_USE_BEFORE)
                 case SUIT_PARAMETER_USE_BEFORE:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_USE_BEFORE)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_USE_BEFORE;
-                    processor_context->parameters[processor_context->component_index].use_before = processor_context->parameters[src_index].use_before;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_USE_BEFORE;
+                    processor_context->b.parameters[processor_context->component_index].use_before = processor_context->b.parameters[src_index].use_before;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_USE_BEFORE */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_MINIMUM_BATTERY)
                 case SUIT_PARAMETER_MINIMUM_BATTERY:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY;
-                    processor_context->parameters[processor_context->component_index].minimum_battery = processor_context->parameters[src_index].minimum_battery;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_MINIMUM_BATTERY;
+                    processor_context->b.parameters[processor_context->component_index].minimum_battery = processor_context->b.parameters[src_index].minimum_battery;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_MINIMUM_BATTERY */
 
                 /* bool */
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_SOFT_FAILURE)
                 case SUIT_PARAMETER_SOFT_FAILURE:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_SOFT_FAILURE)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_SOFT_FAILURE)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOFT_FAILURE;
-                    processor_context->parameters[processor_context->component_index].soft_failure = processor_context->parameters[src_index].soft_failure;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_SOFT_FAILURE;
+                    processor_context->b.parameters[processor_context->component_index].soft_failure = processor_context->b.parameters[src_index].soft_failure;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_SOFT_FAILURE */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_STRICT_ORDER)
                 case SUIT_PARAMETER_STRICT_ORDER:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_STRICT_ORDER)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_STRICT_ORDER)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_STRICT_ORDER;
-                    processor_context->parameters[processor_context->component_index].strict_order = processor_context->parameters[src_index].strict_order;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_STRICT_ORDER;
+                    processor_context->b.parameters[processor_context->component_index].strict_order = processor_context->b.parameters[src_index].strict_order;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_STRICT_ORDER */
 
                 /* tstr */
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_URI)
                 case SUIT_PARAMETER_URI:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_URI)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_URI)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_URI;
-                    processor_context->parameters[processor_context->component_index].uri = processor_context->parameters[src_index].uri;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_URI;
+                    processor_context->b.parameters[processor_context->component_index].uri = processor_context->b.parameters[src_index].uri;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_URI */
 
                 /* bstr */
                 case SUIT_PARAMETER_VENDOR_IDENTIFIER:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].vendor_id = processor_context->parameters[src_index].vendor_id;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VENDOR_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].vendor_id = processor_context->b.parameters[src_index].vendor_id;
                     break;
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_CLASS_IDENTIFIER)
                 case SUIT_PARAMETER_CLASS_IDENTIFIER:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].class_id = processor_context->parameters[src_index].class_id;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CLASS_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].class_id = processor_context->b.parameters[src_index].class_id;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_CLASS_IDENTIFIER */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_DEVICE_IDENTIFIER)
                 case SUIT_PARAMETER_DEVICE_IDENTIFIER:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER;
-                    processor_context->parameters[processor_context->component_index].device_id = processor_context->parameters[src_index].device_id;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_DEVICE_IDENTIFIER;
+                    processor_context->b.parameters[processor_context->component_index].device_id = processor_context->b.parameters[src_index].device_id;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_DEVICE_IDENTIFIER */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_CONTENT)
                 case SUIT_PARAMETER_CONTENT:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_CONTENT)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CONTENT;
-                    processor_context->parameters[processor_context->component_index].content = processor_context->parameters[src_index].content;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_CONTENT;
+                    processor_context->b.parameters[processor_context->component_index].content = processor_context->b.parameters[src_index].content;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_CONTENT */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_INVOKE_ARGS)
                 case SUIT_PARAMETER_INVOKE_ARGS:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_INVOKE_ARGS)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_INVOKE_ARGS)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_INVOKE_ARGS;
-                    processor_context->parameters[processor_context->component_index].invoke_args = processor_context->parameters[src_index].invoke_args;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_INVOKE_ARGS;
+                    processor_context->b.parameters[processor_context->component_index].invoke_args = processor_context->b.parameters[src_index].invoke_args;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_INVOKE_ARGS */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS)
                 case SUIT_PARAMETER_FETCH_ARGS:
-                    if (!(processor_context->parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS)) {
+                    if (!(processor_context->b.parameters[processor_context->component_index].exists & SUIT_PARAMETER_CONTAINS_FETCH_ARGS)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_FETCH_ARGS;
-                    processor_context->parameters[processor_context->component_index].fetch_args = processor_context->parameters[src_index].fetch_args;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_FETCH_ARGS;
+                    processor_context->b.parameters[processor_context->component_index].fetch_args = processor_context->b.parameters[src_index].fetch_args;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_FETCH_ARGS */
 
                 /* bstr .cbor COSE_Encrypt0 // bstr .cbor COSE_Encrypt */
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_ENCRYPTION_INFO)
                 case SUIT_PARAMETER_ENCRYPTION_INFO:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO;
-                    processor_context->parameters[processor_context->component_index].encryption_info = processor_context->parameters[src_index].encryption_info;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO;
+                    processor_context->b.parameters[processor_context->component_index].encryption_info = processor_context->b.parameters[src_index].encryption_info;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_ENCRYPTION_INFO */
 
                 /* bstr .cbor SUIT_Diget */
                 case SUIT_PARAMETER_IMAGE_DIGEST:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_ENCRYPTION_INFO)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST;
-                    processor_context->parameters[processor_context->component_index].image_digest_buf = processor_context->parameters[src_index].image_digest_buf;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_IMAGE_DIGEST;
+                    processor_context->b.parameters[processor_context->component_index].image_digest_buf = processor_context->b.parameters[src_index].image_digest_buf;
                     break;
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_VERSION)
                 /* SUIT_Parameter_Version_Match */
                 case SUIT_PARAMETER_VERSION:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_VERSION)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_VERSION)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VERSION;
-                    processor_context->parameters[processor_context->component_index].version_match_buf = processor_context->parameters[src_index].version_match_buf;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_VERSION;
+                    processor_context->b.parameters[processor_context->component_index].version_match_buf = processor_context->b.parameters[src_index].version_match_buf;
                     break;
 #endif
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_WAIT_INFO)
                 /* SUIT_Wait_Event */
                 case SUIT_PARAMETER_WAIT_INFO:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_CONTAINS_WAIT_INFO)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_WAIT_INFO;
-                    processor_context->parameters[processor_context->component_index].wait_info_buf = processor_context->parameters[src_index].wait_info_buf;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_WAIT_INFO;
+                    processor_context->b.parameters[processor_context->component_index].wait_info_buf = processor_context->b.parameters[src_index].wait_info_buf;
                     break;
 #endif /* !LIBCSUIT_DISABLE_PARAMETER_WAIT_INFO */
 
 #if !defined(LIBCSUIT_DISABLE_PARAMETER_COMPONENT_METADATA)
                 /* SUIT_Component_Metadata */
                 case SUIT_PARAMETER_COMPONENT_METADATA:
-                    if (!(processor_context->parameters[src_index].exists & SUIT_PARAMETER_COMPONENT_METADATA)) {
+                    if (!(processor_context->b.parameters[src_index].exists & SUIT_PARAMETER_COMPONENT_METADATA)) {
                         return SUIT_ERR_PARAMETER_NOT_FOUND;
                     }
-                    processor_context->parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA;
-                    processor_context->parameters[processor_context->component_index].component_metadata_buf = processor_context->parameters[src_index].component_metadata_buf;
+                    processor_context->b.parameters[processor_context->component_index].exists |= SUIT_PARAMETER_CONTAINS_COMPONENT_METADATA;
+                    processor_context->b.parameters[processor_context->component_index].component_metadata_buf = processor_context->b.parameters[src_index].component_metadata_buf;
                     break;
 #endif
 
@@ -1607,8 +1622,10 @@ suit_err_t suit_process_dependency(suit_processor_context_t *processor_context,
     suit_err_t result = SUIT_SUCCESS;
 
     for (size_t i = 0; i < suit_index->len; i++) {
+        if (processor_context->dependency_tree.len + 1 >= SUIT_MAX_DEPENDENCY_LENGTH) {
+            return SUIT_ERR_NO_MEMORY;
+        }
         processor_context->component_index = suit_index->index[i];
-
         result = suit_index_is_dependency(extracted, processor_context->component_index);
         if (result != SUIT_SUCCESS) {
             goto report;
@@ -1620,20 +1637,17 @@ suit_err_t suit_process_dependency(suit_processor_context_t *processor_context,
             goto report;
         }
 
+        // backup several contexts
+        UsefulBufC manifest_backup = processor_context->b.manifest;
+        UsefulBufC manifest_digest_backup = processor_context->b.manifest_digest;
+        suit_process_flag_t process_flags_backup = processor_context->process_flags;
+
         // OK, let's dive into the dependency manifest
         processor_context->dependency_tree.manifest_index[processor_context->dependency_tree.len] = processor_context->component_index;
         processor_context->dependency_tree.len++;
-        result = suit_decode_digest(processor_context->parameters[processor_context->component_index].image_digest_buf, &processor_context->expected_manifest_digest);
-        if (result != SUIT_SUCCESS) {
-            processor_context->reason = SUIT_REPORT_REASON_CBOR_PARSE;
-            return result;
-        }
-
-        UsefulBufC manifest_backup = processor_context->manifest;
-        processor_context->manifest = payload->bytes;
-
+        processor_context->b.manifest = payload->bytes;
+        processor_context->b.manifest_digest = processor_context->b.parameters[processor_context->component_index].image_digest_buf;
         // checks only suit-delegation and suit-authentication-wrapper
-        suit_process_flag_t process_flags_backup = processor_context->process_flags;
         processor_context->process_flags = suit_manifest_key_to_process_flag(processor_context->manifest_key);
 
         /*
@@ -1645,7 +1659,8 @@ suit_err_t suit_process_dependency(suit_processor_context_t *processor_context,
 
         // recover the context
         processor_context->process_flags = process_flags_backup;
-        processor_context->manifest = manifest_backup;
+        processor_context->b.manifest_digest = manifest_digest_backup;
+        processor_context->b.manifest = manifest_backup;
         processor_context->dependency_tree.len--;
 
 report:
@@ -2004,7 +2019,7 @@ suit_err_t suit_process_common_and_command_sequence(suit_processor_context_t *pr
 {
     suit_err_t result = SUIT_SUCCESS;
     for (size_t i = 0; i < SUIT_MAX_INDEX_NUM; i++) {
-        processor_context->parameters[i].soft_failure = true;
+        processor_context->b.parameters[i].soft_failure = true;
     }
 
     UsefulBufC command_buf;
@@ -2088,24 +2103,31 @@ suit_err_t suit_process_digest(QCBORDecodeContext *context,
 }
 
 suit_err_t suit_process_authentication_wrapper(QCBORDecodeContext *context,
-                                               suit_processor_context_t *processor_context,
-                                               suit_digest_t *digest)
+                                               suit_processor_context_t *processor_context)
 {
     QCBORItem item;
+    UsefulBufC manifest_digest;
 
     /* authentication-wrapper */
     QCBORDecode_EnterBstrWrapped(context, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+
     QCBORDecode_EnterArray(context, &item);
-    size_t length = item.val.uCount;
-    if (length < 1) {
+
+    if (item.uDataType != QCBOR_TYPE_ARRAY || item.val.uCount < 1) {
         return SUIT_ERR_FAILED_TO_VERIFY;
     }
+    size_t length = item.val.uCount;
 
     /* digest */
-    UsefulBufC digest_buf;
-    suit_err_t result = suit_process_digest(context, digest, &digest_buf);
-    if (result != SUIT_SUCCESS) {
-        return result;
+    QCBORDecode_GetByteString(context, &manifest_digest);
+    if (processor_context->b.manifest_digest.len > 0) {
+        /*
+         * Check with expected digest
+         * mainly for suit-condition-dependency-integrity
+         */
+        if (UsefulBuf_Compare(processor_context->b.manifest_digest, manifest_digest) != 0) {
+            return SUIT_ERR_FAILED_TO_VERIFY;
+        }
     }
 
     /* signatures */
@@ -2118,12 +2140,13 @@ suit_err_t suit_process_authentication_wrapper(QCBORDecodeContext *context,
         }
         size_t j = 0;
         for (; j < SUIT_MAX_KEY_NUM; j++) {
+            suit_err_t result = SUIT_ERR_FAILED_TO_VERIFY;
             switch (processor_context->mechanisms[j].cose_tag) {
             case COSE_SIGN1_TAG:
-                result = suit_verify_cose_sign1(signature, &processor_context->mechanisms[j].key, &digest_buf);
+                result = suit_verify_cose_sign1(signature, &processor_context->mechanisms[j].key, &manifest_digest);
                 break;
             case COSE_MAC0_TAG:
-                result = suit_validate_cose_mac0(signature, &processor_context->mechanisms[j].key, &digest_buf);
+                result = suit_validate_cose_mac0(signature, &processor_context->mechanisms[j].key, &manifest_digest);
                 break;
             default:
                 continue;
@@ -2141,14 +2164,18 @@ suit_err_t suit_process_authentication_wrapper(QCBORDecodeContext *context,
         return suit_error_from_qcbor_error(error);
     }
 
+    if (verified) {
+        // trigger callbacks
 #if !defined(LIBCSUIT_DISABLE_SUIT_REPORT)
-    if (verified && processor_context->reporting_engine != NULL) {
-        suit_report_manifest_digest(
-            processor_context->reporting_engine,
-            *digest
-        );
-    }
+        if (processor_context->reporting_engine != NULL) {
+            suit_report_manifest_digest(
+                processor_context->reporting_engine,
+                manifest_digest
+            );
+        }
 #endif /* LIBCSUIT_DISABLE_SUIT_REPORT */
+        processor_context->b.manifest_digest = manifest_digest;
+    }
 
     return (verified) ? SUIT_SUCCESS : SUIT_ERR_FAILED_TO_VERIFY;
 }
@@ -2285,7 +2312,7 @@ suit_err_t suit_extract_manifest(suit_processor_context_t *processor_context, su
             if (error != QCBOR_SUCCESS) {
                 goto out;
             }
-            if (!(item.uDataType == QCBOR_TYPE_INT64 || item.uDataType == QCBOR_TYPE_UINT64)) {
+            if (!suit_qcbor_value_is_uint64(&item)) {
                 result = SUIT_ERR_INVALID_TYPE_OF_VALUE;
                 goto out;
             }
@@ -2305,11 +2332,11 @@ suit_err_t suit_extract_manifest(suit_processor_context_t *processor_context, su
             if (error != QCBOR_SUCCESS) {
                 goto out;
             }
-            if (!(item.uDataType == QCBOR_TYPE_INT64 || item.uDataType == QCBOR_TYPE_UINT64)) {
+            if (!suit_qcbor_value_is_uint64(&item)) {
                 result = SUIT_ERR_INVALID_TYPE_OF_VALUE;
                 goto out;
             }
-            // TODO: check sequence-number
+            processor_context->b.manifest_sequence_number = item.val.uint64;
             break;
 
         case SUIT_COMMON:
@@ -2619,7 +2646,7 @@ suit_err_t suit_process_envelope(suit_processor_context_t *processor_context)
 
     /* extract items */
     QCBORDecode_Init(&context,
-                     (UsefulBufC){processor_context->manifest.ptr, processor_context->manifest.len},
+                     (UsefulBufC){processor_context->b.manifest.ptr, processor_context->b.manifest.len},
                      QCBOR_DECODE_MODE_NORMAL);
     QCBORDecode_EnterMap(&context, &item);
     size_t length = item.val.uCount;
@@ -2657,28 +2684,19 @@ suit_err_t suit_process_envelope(suit_processor_context_t *processor_context)
 #endif
 
             case SUIT_AUTHENTICATION:
-                result = suit_process_authentication_wrapper(&context, processor_context, &manifest_digest);
+                result = suit_process_authentication_wrapper(&context, processor_context);
                 if (result != SUIT_SUCCESS) {
                     processor_context->final_state = result;
-                    goto report;
-                }
-
-                /*
-                 * Check with expected digest
-                 * mainly for suit-condition-dependency-integrity
-                 */
-                if (processor_context->expected_manifest_digest.bytes.len > 0) {
-                    if (processor_context->expected_manifest_digest.bytes.len != manifest_digest.bytes.len ||
-                        memcmp(processor_context->expected_manifest_digest.bytes.ptr, manifest_digest.bytes.ptr, manifest_digest.bytes.len) != 0) {
-                        result = SUIT_ERR_FAILED_TO_VERIFY;
+                    if (result == SUIT_ERR_FAILED_TO_VERIFY) {
                         processor_context->reason = SUIT_REPORT_REASON_UNAUTHORIZED;
-                        goto report;
                     }
+                    goto report;
                 }
                 break;
 
             case SUIT_MANIFEST:
-                if (manifest_digest.algorithm_id == SUIT_ALGORITHM_ID_INVALID) {
+                result = suit_decode_digest(processor_context->b.manifest_digest, &manifest_digest);
+                if (result != SUIT_SUCCESS || manifest_digest.algorithm_id == SUIT_ALGORITHM_ID_INVALID) {
                     result = SUIT_ERR_AUTHENTICATION_NOT_FOUND;
                     processor_context->reason = SUIT_REPORT_REASON_UNAUTHORIZED;
                     goto report;
@@ -2785,9 +2803,13 @@ suit_err_t suit_process_envelope(suit_processor_context_t *processor_context)
         processor_context->manifest_key = SUIT_MANIFEST_COMPONENT_ID;
         if (extracted.manifest_component_id.len > 0) {
             suit_store_args_t store = {0};
+            store.manifest_digest = processor_context->b.manifest_digest;
+            store.manifest_sequence_number = processor_context->b.manifest_sequence_number;
+            store.is_manifest_itself = true;
+
             store.report_policy.val = 0;
             store.dst = extracted.manifest_component_id;
-            store.src_buf = processor_context->manifest;
+            store.src_buf = processor_context->b.manifest;
             store.operation = SUIT_STORE;
 
             suit_callback_ret_t ret = {0};
@@ -2983,14 +3005,14 @@ suit_err_t suit_processor_add_manifest(
     if (processor_context->u.manifest_loaded) {
         return SUIT_ERR_INITIALIZED_AGAIN;
     }
-    if (manifest.ptr != processor_context->manifest.ptr) {
+    if (manifest.ptr != processor_context->b.manifest.ptr) {
         return SUIT_ERR_INVALID_VALUE;
     }
-    if (manifest.len > processor_context->manifest.len) {
+    if (manifest.len > processor_context->b.manifest.len) {
         return SUIT_ERR_INVALID_VALUE;
     }
 
-    processor_context->manifest = manifest;
+    processor_context->b.manifest = manifest;
     processor_context->left_len -= manifest.len;
     processor_context->process_flags = process_flags;
     processor_context->u.manifest_loaded = 1;
@@ -3077,9 +3099,9 @@ suit_err_t suit_processor_init(
     processor_context->allocated.len = buf_size;
     processor_context->left_len = buf_size;
 
-    processor_context->manifest.ptr = processor_context->buf;
-    processor_context->manifest.len = buf_size;
-    *manifest = UsefulBuf_Unconst(processor_context->manifest);
+    processor_context->b.manifest.ptr = processor_context->buf;
+    processor_context->b.manifest.len = buf_size;
+    *manifest = UsefulBuf_Unconst(processor_context->b.manifest);
 
     processor_context->u.initialized = 1;
     return SUIT_SUCCESS;

--- a/src/suit_report_print.c
+++ b/src/suit_report_print.c
@@ -202,7 +202,7 @@ void suit_print_suit_parameters_from_item(QCBORDecodeContext *context,
                 printf(",\n");
             }
             printf("%*s/ system-component-id / 0: ", indent_space + indent_delta, "");
-            if (suit_decode_component_identifiers_from_item(context, item, false, &v.component_identifier)) {
+            if (suit_decode_component_identifier_from_item(context, item, false, &v.component_identifier)) {
                 return;
             }
             suit_print_component_identifier(&v.component_identifier);

--- a/src/suit_reporting_engine.c
+++ b/src/suit_reporting_engine.c
@@ -404,7 +404,7 @@ suit_err_t suit_report_extend_record(
 suit_err_t suit_report_extend_system_property_claims(
     suit_report_context_t *report_context,
     const uint8_t component_index,
-    const suit_component_identifier_t *component,
+    UsefulBufC component,
     const suit_parameter_key_t parameter_keys[],
     const struct suit_union_parameter *parameter_value)
 {
@@ -430,7 +430,7 @@ suit_err_t suit_report_extend_system_property_claims(
             //   system-component-id
             QCBOREncode_AddUInt64(&report_context->cbor_encoder, 0);
             //   => SUIT_Component_Identifier,
-            suit_encode_append_component_identifier(component, 0, &report_context->cbor_encoder);
+            QCBOREncode_AddEncoded(&report_context->cbor_encoder, component);
             report_context->current_index = component_index;
         }
         break;
@@ -440,7 +440,7 @@ suit_err_t suit_report_extend_system_property_claims(
         //   system-component-id
         QCBOREncode_AddUInt64(&report_context->cbor_encoder, 0);
         //   => SUIT_Component_Identifier,
-        suit_encode_append_component_identifier(component, 0, &report_context->cbor_encoder);
+        QCBOREncode_AddEncoded(&report_context->cbor_encoder, component);
         report_context->current_index = component_index;
         break;
     default:

--- a/src/suit_reporting_engine.c
+++ b/src/suit_reporting_engine.c
@@ -477,7 +477,7 @@ suit_err_t suit_report_manifest_reference_uri(
     // ]
     QCBOREncode_OpenArrayInMapN(&report_context->cbor_encoder, SUIT_REPORT_REFERENCE);
     QCBOREncode_AddText(&report_context->cbor_encoder, reference_uri);
-    suit_encode_append_digest(&report_context->digest, 0, &report_context->cbor_encoder);
+    QCBOREncode_AddEncoded(&report_context->cbor_encoder, report_context->manifest_digest);
     QCBOREncode_CloseArray(&report_context->cbor_encoder);
 
     // suit-report-records => [
@@ -489,12 +489,12 @@ suit_err_t suit_report_manifest_reference_uri(
 
 suit_err_t suit_report_manifest_digest(
     suit_report_context_t *report_context,
-    suit_digest_t digest)
+    UsefulBufC manifest_digest)
 {
     if (report_context->state != SUIT_REPORTING_ENGINE_STARTED) {
         return SUIT_ERR_WHILE_REPORTING;
     }
-    report_context->digest = digest;
+    report_context->manifest_digest = manifest_digest;
     report_context->state = SUIT_REPORTING_ENGINE_SUIT_DIGEST_STORED;
 
     return SUIT_SUCCESS;

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,8 +15,15 @@ LDFLAGS ?= -lt_cose -lqcbor -lcunit -lm
 
 include ../common.mk
 
-$(TARGET): main.c ../libcsuit.a
-	$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS) $(INC)
+LDWRAP = \
+	-Xlinker --wrap=suit_fetch_callback \
+	-Xlinker --wrap=suit_store_callback \
+	-Xlinker --wrap=suit_invoke_callback \
+	-Xlinker --wrap=suit_condition_callback \
+	-Xlinker --wrap=suit_report_callback
+
+$(TARGET): process_test.c main.c ../libcsuit.a
+	$(CC) $(LDWRAP) -o $@ $^ $(CFLAGS) $(LDFLAGS) $(INC)
 
 ../libcsuit.a:
 	$(MAKE) -C ../ MBEDTLS=$(MBEDTLS)

--- a/test/main.c
+++ b/test/main.c
@@ -381,15 +381,16 @@ void test_csuit_report_example0_success_report(void)
     CU_ASSERT_EQUAL_FATAL(suit_report_add_sender_key(reporting_engine, CBOR_TAG_COSE_SIGN1, T_COSE_ALGORITHM_RESERVED, &sender_key), SUIT_SUCCESS);
     UsefulBufC nonce = NULLUsefulBufC;
     suit_report_start_encoding(reporting_engine, nonce);
-    uint8_t bytes[] = {
+    uint8_t manifest_digest_bytes[] = {
+        0x82, // array(2)
+        0x2F, // negative(15) = -16, T_COSE_ALGORITHM_SHA_256
+        0x58, 0x20,
         0x66, 0x58, 0xEA, 0x56, 0x02, 0x62, 0x69, 0x6D,
         0xD1, 0xF1, 0x3B, 0x78, 0x22, 0x39, 0xA0, 0x64,
         0xDA, 0x7C, 0x6C, 0x5C, 0xBA, 0xF5, 0x2F, 0xDE,
         0xD4, 0x28, 0xA6, 0xFC, 0x83, 0xC7, 0xE5, 0xAF,
     };
-    UsefulBufC digest_bytes = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bytes);
-    suit_digest_t digest = {.algorithm_id = T_COSE_ALGORITHM_SHA_256, .bytes = digest_bytes};
-    CU_ASSERT_EQUAL_FATAL(suit_report_manifest_digest(reporting_engine, digest), SUIT_SUCCESS);
+    CU_ASSERT_EQUAL_FATAL(suit_report_manifest_digest(reporting_engine, UsefulBuf_FROM_BYTE_ARRAY_LITERAL(manifest_digest_bytes)), SUIT_SUCCESS);
     CU_ASSERT_EQUAL_FATAL(suit_report_manifest_reference_uri(reporting_engine, UsefulBuf_FROM_SZ_LITERAL("http://example.com/manifest.suit")), SUIT_SUCCESS);
 
     suit_component_identifier_t component;
@@ -496,15 +497,16 @@ void test_csuit_report_example0_failure_report(void)
     CU_ASSERT_EQUAL_FATAL(suit_report_add_sender_key(reporting_engine, CBOR_TAG_COSE_SIGN1, T_COSE_ALGORITHM_RESERVED, &sender_key), SUIT_SUCCESS);
     UsefulBufC nonce = NULLUsefulBufC;
     CU_ASSERT_EQUAL_FATAL(suit_report_start_encoding(reporting_engine, nonce), SUIT_SUCCESS);
-    uint8_t bytes[] = {
+    uint8_t manifest_digest_bytes[] = {
+        0x82, // array(2)
+        0x2F, // negative(15) = -16, T_COSE_ALGORITHM_SHA_256
+        0x58, 0x20,
         0x66, 0x58, 0xEA, 0x56, 0x02, 0x62, 0x69, 0x6D,
         0xD1, 0xF1, 0x3B, 0x78, 0x22, 0x39, 0xA0, 0x64,
         0xDA, 0x7C, 0x6C, 0x5C, 0xBA, 0xF5, 0x2F, 0xDE,
         0xD4, 0x28, 0xA6, 0xFC, 0x83, 0xC7, 0xE5, 0xAF,
     };
-    UsefulBufC digest_bytes = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(bytes);
-    suit_digest_t digest = {.algorithm_id = T_COSE_ALGORITHM_SHA_256, .bytes = digest_bytes};
-    CU_ASSERT_EQUAL_FATAL(suit_report_manifest_digest(reporting_engine, digest), SUIT_SUCCESS);
+    CU_ASSERT_EQUAL_FATAL(suit_report_manifest_digest(reporting_engine, UsefulBuf_FROM_BYTE_ARRAY_LITERAL(manifest_digest_bytes)), SUIT_SUCCESS);
     CU_ASSERT_EQUAL_FATAL(suit_report_manifest_reference_uri(reporting_engine, UsefulBuf_FROM_SZ_LITERAL("http://example.com/manifest.suit")), SUIT_SUCCESS);
 
     suit_component_identifier_t component;

--- a/test/process_test.c
+++ b/test/process_test.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2020-2026 SECOM CO., LTD. All Rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdlib.h>
+#include "csuit/csuit.h"
+#include "qcbor/qcbor_spiffy_decode.h"
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+#include "../examples/inc/trust_anchor_esp256_cose_key_public.h"
+
+#define BUFFER_SIZE 4096
+#define REPORT_SIZE 1024
+
+unsigned char testfiles_suit_manifest_exp0_suit[] = {
+    0xd8, 0x6b, 0xa2, 0x02, 0x58, 0x73, 0x82, 0x58, 0x24, 0x82, 0x2f, 0x58,
+    0x20, 0x66, 0x58, 0xea, 0x56, 0x02, 0x62, 0x69, 0x6d, 0xd1, 0xf1, 0x3b,
+    0x78, 0x22, 0x39, 0xa0, 0x64, 0xda, 0x7c, 0x6c, 0x5c, 0xba, 0xf5, 0x2f,
+    0xde, 0xd4, 0x28, 0xa6, 0xfc, 0x83, 0xc7, 0xe5, 0xaf, 0x58, 0x4a, 0xd2,
+    0x84, 0x43, 0xa1, 0x01, 0x28, 0xa0, 0xf6, 0x58, 0x40, 0x86, 0x79, 0xa7,
+    0xbd, 0xe3, 0x16, 0xa9, 0xc8, 0xa7, 0xdd, 0x70, 0x1f, 0x3f, 0x15, 0x3f,
+    0x01, 0x13, 0x68, 0x74, 0x9f, 0xce, 0x6c, 0x12, 0xe4, 0xe2, 0xc9, 0xf7,
+    0x04, 0xd3, 0xbd, 0x10, 0x4f, 0xb7, 0x75, 0x59, 0xd2, 0xd9, 0x72, 0x3a,
+    0xc9, 0xce, 0x55, 0x0d, 0xc6, 0x9e, 0x7b, 0xf8, 0xcc, 0x3a, 0x1a, 0x46,
+    0x0d, 0xc6, 0xf2, 0xb8, 0x51, 0x78, 0x0b, 0xd2, 0x3c, 0xf6, 0x66, 0x9c,
+    0x29, 0x03, 0x58, 0x71, 0xa5, 0x01, 0x01, 0x02, 0x00, 0x03, 0x58, 0x5f,
+    0xa2, 0x02, 0x81, 0x81, 0x41, 0x00, 0x04, 0x58, 0x56, 0x86, 0x14, 0xa4,
+    0x01, 0x50, 0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf, 0xbe, 0x9d,
+    0xe6, 0x63, 0xe4, 0xd4, 0x1f, 0xfe, 0x02, 0x50, 0x14, 0x92, 0xaf, 0x14,
+    0x25, 0x69, 0x5e, 0x48, 0xbf, 0x42, 0x9b, 0x2d, 0x51, 0xf2, 0xab, 0x45,
+    0x03, 0x58, 0x24, 0x82, 0x2f, 0x58, 0x20, 0x00, 0x11, 0x22, 0x33, 0x44,
+    0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01,
+    0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76,
+    0x54, 0x32, 0x10, 0x0e, 0x19, 0x87, 0xd0, 0x01, 0x0f, 0x02, 0x0f, 0x07,
+    0x43, 0x82, 0x03, 0x0f, 0x09, 0x43, 0x82, 0x17, 0x02
+};
+unsigned int testfiles_suit_manifest_exp0_suit_len = 237;
+
+size_t g_pos;
+enum callback_type {
+    SUIT_CALLBACK_INVALID = 0, // sentinel
+    SUIT_CALLBACK_STORE,
+    SUIT_CALLBACK_FETCH,
+    SUIT_CALLBACK_CONDITION,
+    SUIT_CALLBACK_INVOKE,
+};
+union callback_arg {
+    struct {
+        suit_con_dir_key_t key;
+        suit_union_parameter_t condition;
+    };
+    UsefulBufC invoke_arg;
+};
+struct expected_callback_func_args {
+    enum callback_type type;
+    UsefulBufC src;
+    UsefulBufC dst;
+    UsefulBufC manifest_digest;
+    uint64_t manifest_sequence_number;
+    union callback_arg arg;
+};
+#define NUM_CALLBACKS 32
+struct expected_callback_func_args g_args[NUM_CALLBACKS];
+
+uint8_t vendor_id[] = {
+    0xfa, 0x6b, 0x4a, 0x53, 0xd5, 0xad, 0x5f, 0xdf, 0xbe, 0x9d, 0xe6, 0x63, 0xe4, 0xd4, 0x1f, 0xfe
+};
+uint8_t class_id[] = {
+    0x14, 0x92, 0xaf, 0x14, 0x25, 0x69, 0x5e, 0x48, 0xbf, 0x42, 0x9b, 0x2d, 0x51, 0xf2, 0xab, 0x45, 
+};
+uint8_t image_digest[] = {
+    0x82, // array(2)
+    0x2f, // negative(15) = -16, SHA-256
+    0x58, 0x20, // bytes(32)
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10, 
+};
+
+suit_err_t __wrap_suit_fetch_callback(suit_fetch_args_t args, suit_callback_ret_t *ret)
+{
+    CU_FAIL()
+    return SUIT_SUCCESS;
+}
+
+suit_err_t __wrap_suit_store_callback(suit_store_args_t args, suit_callback_ret_t *ret)
+{
+    CU_FAIL();
+    return SUIT_SUCCESS;
+}
+
+suit_err_t __wrap_suit_invoke_callback(suit_invoke_args_t invoke_args)
+{
+    CU_ASSERT_FATAL(g_pos < NUM_CALLBACKS);
+    CU_ASSERT_EQUAL_FATAL(SUIT_CALLBACK_INVOKE, g_args[g_pos].type);
+    CU_ASSERT_EQUAL(UsefulBuf_Compare(invoke_args.manifest_digest, g_args[g_pos].manifest_digest), 0);
+
+    CU_ASSERT_EQUAL(UsefulBuf_Compare(invoke_args.encoded_component_identifier, g_args[g_pos].dst), 0);
+    CU_ASSERT_EQUAL_FATAL(invoke_args.args_len, g_args[g_pos].arg.invoke_arg.len);
+    CU_ASSERT_EQUAL(memcmp(invoke_args.args, g_args[g_pos].arg.invoke_arg.ptr, invoke_args.args_len), 0);
+
+    return SUIT_SUCCESS;
+}
+
+suit_err_t __wrap_suit_condition_callback(suit_condition_args_t condition_args, suit_callback_ret_t *condition_ret)
+{
+    CU_ASSERT_FATAL(g_pos < NUM_CALLBACKS);
+    CU_ASSERT_EQUAL_FATAL(SUIT_CALLBACK_CONDITION, g_args[g_pos].type);
+    CU_ASSERT_EQUAL(UsefulBuf_Compare(condition_args.manifest_digest, g_args[g_pos].manifest_digest), 0);
+
+    CU_ASSERT_EQUAL(UsefulBuf_Compare(condition_args.dst, g_args[g_pos].dst), 0);
+    CU_ASSERT_EQUAL(condition_args.condition, g_args[g_pos].arg.key);
+    switch (condition_args.condition) {
+    /* compare bstr or tstr */
+    case SUIT_CONDITION_VENDOR_IDENTIFIER:
+    case SUIT_CONDITION_CLASS_IDENTIFIER:
+    case SUIT_CONDITION_DEVICE_IDENTIFIER:
+    case SUIT_CONDITION_CHECK_CONTENT:
+    case SUIT_CONDITION_IMAGE_NOT_MATCH:
+        CU_ASSERT_EQUAL(UsefulBuf_Compare(condition_args.expected.str, g_args[g_pos].arg.condition.str), 0);
+        break;
+
+    /* compare bstr and uint64 */
+    case SUIT_CONDITION_IMAGE_MATCH:
+    case SUIT_CONDITION_VERSION:        
+        CU_ASSERT_EQUAL(UsefulBuf_Compare(condition_args.expected.str, g_args[g_pos].arg.condition.str), 0);
+        CU_ASSERT_EQUAL(condition_args.expected.u64, g_args[g_pos].arg.condition.u64);
+        break;
+
+    /* compare int64 */
+    case SUIT_CONDITION_USE_BEFORE:
+        CU_ASSERT_EQUAL(condition_args.expected.i64, g_args[g_pos].arg.condition.i64);
+        break;
+
+    /* compare uint64 */
+    case SUIT_CONDITION_COMPONENT_SLOT:
+    case SUIT_CONDITION_MINIMUM_BATTERY:
+    case SUIT_CONDITION_UPDATE_AUTHORIZED:
+        CU_ASSERT_EQUAL(condition_args.expected.u64, g_args[g_pos].arg.condition.u64);
+        break;
+
+    /* should not be called */
+    case SUIT_CONDITION_ABORT:
+    case SUIT_CONDITION_IS_DEPENDENCY:
+    case SUIT_CONDITION_DEPENDENCY_INTEGRITY:
+    default:
+        CU_FAIL();
+    }
+
+    g_pos++;
+    return SUIT_SUCCESS;
+}
+
+suit_err_t __wrap_suit_report_callback(suit_report_args_t arg)
+{
+    // pass
+    return SUIT_SUCCESS;
+}
+
+void test_process_example0(void)
+{
+    g_pos = 0;
+    uint8_t example0_digest_bytes[] = {
+        0x82, // array(2)
+        0x2f, // negative(15) = -16, SHA-256
+        0x58, 0x20, // bytes(32)
+        0x66, 0x58, 0xea, 0x56, 0x02, 0x62, 0x69, 0x6d, 0xd1, 0xf1, 0x3b, 0x78, 0x22, 0x39, 0xa0, 0x64, 0xda, 0x7c, 0x6c, 0x5c, 0xba, 0xf5, 0x2f, 0xde, 0xd4, 0x28, 0xa6, 0xfc, 0x83, 0xc7, 0xe5, 0xaf,
+    };
+    UsefulBufC example0_digest = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(example0_digest_bytes);
+    uint8_t example0_component0_bytes[] = {
+        0x81, 0x41, 0x00, // [ h'00' ]
+    };
+    UsefulBufC example0_component = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(example0_component0_bytes);
+
+    /* set expected sequence of callback functions and their arguments for example 0 */
+    memset(g_args, 0, sizeof(g_args));
+    // validate, shared-sequence
+    g_args[0] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_CONDITION,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.key = SUIT_CONDITION_VENDOR_IDENTIFIER,
+        .arg.condition = (suit_union_parameter_t){
+            .str = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(vendor_id)
+        }
+    };
+    g_args[1] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_CONDITION,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.key = SUIT_CONDITION_CLASS_IDENTIFIER,
+        .arg.condition = (suit_union_parameter_t){
+            .str = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(class_id)
+        }
+    };
+    // validate
+    g_args[2] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_CONDITION,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.key = SUIT_CONDITION_IMAGE_MATCH,
+        .arg.condition = (suit_union_parameter_t){
+            .u64 = 34768,
+            .str = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(image_digest)
+        }
+    };
+    // invoke, shared-sequence
+    g_args[3] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_CONDITION,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.key = SUIT_CONDITION_VENDOR_IDENTIFIER,
+        .arg.condition = (suit_union_parameter_t){
+            .str = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(vendor_id)
+        }
+    };
+    g_args[4] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_CONDITION,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.key = SUIT_PARAMETER_CLASS_IDENTIFIER,
+        .arg.condition = (suit_union_parameter_t){
+            .str = UsefulBuf_FROM_BYTE_ARRAY_LITERAL(class_id)
+        }
+    };
+    g_args[5] = (struct expected_callback_func_args){
+        .type = SUIT_CALLBACK_INVOKE,
+        .manifest_digest = example0_digest,
+        .dst = example0_component,
+        .arg.invoke_arg = NULLUsefulBufC
+    };
+
+    suit_report_context_t *reporting_engine = malloc(sizeof(suit_report_context_t) + REPORT_SIZE);
+    CU_ASSERT_PTR_NOT_NULL(reporting_engine);
+    suit_processor_context_t *processor_context = malloc(sizeof(suit_processor_context_t) + BUFFER_SIZE);
+    CU_ASSERT_PTR_NOT_NULL(reporting_engine);
+    
+    suit_report_init_engine(reporting_engine, REPORT_SIZE);
+    UsefulBufC nonce = NULLUsefulBufC;
+    suit_report_start_encoding(reporting_engine, nonce);
+
+    UsefulBuf manifest_buf;
+    bool report_invoke_pending = true;
+    suit_processor_init(processor_context, BUFFER_SIZE, reporting_engine, report_invoke_pending, &manifest_buf);
+    memcpy(manifest_buf.ptr, testfiles_suit_manifest_exp0_suit, testfiles_suit_manifest_exp0_suit_len);
+    manifest_buf.len = testfiles_suit_manifest_exp0_suit_len;
+    suit_process_flag_t process_flags;
+    process_flags.all = UINT16_MAX;
+    process_flags.uninstall = 0;
+
+    CU_ASSERT_EQUAL_FATAL(suit_processor_add_manifest(processor_context, UsefulBuf_Const(manifest_buf), process_flags), SUIT_SUCCESS);
+    suit_key_t signer_key;
+    CU_ASSERT_EQUAL_FATAL(suit_set_suit_key_from_cose_key(trust_anchor_esp256_cose_key_public, &signer_key), SUIT_SUCCESS);
+    CU_ASSERT_EQUAL_FATAL(suit_processor_add_recipient_key(processor_context, CBOR_TAG_COSE_SIGN1, T_COSE_ALGORITHM_ESP256, &signer_key), SUIT_SUCCESS);
+    CU_ASSERT_EQUAL_FATAL(suit_process_envelope(processor_context), SUIT_SUCCESS);
+}


### PR DESCRIPTION
This Pull Request adds following arguments:
- manifest_digest
- manifest_sequence_number
- is_manifest_itself (only true in suit-component-id section)

Reason:
When the store and fetch callback functions are triggered, they need to look up the existing component and compare the suit-manifest-sequence-number to prevent rollback.
The manifest_digest is supplemental information to identify which SUIT manifest is processing.
As SUIT manifests can be also treated as components, the SUIT Manifest Processor triggers `suit_store_callback` to notify a manifest contains `suit-component-id` section specifying the component-id itself. In such situation, the is_manifest_itself is true.

TODO: test their values are expected ones with manifests in testfiles.